### PR TITLE
Directives, mostly

### DIFF
--- a/src/api/src/_gen/client-types.ts
+++ b/src/api/src/_gen/client-types.ts
@@ -82,6 +82,13 @@ export type DatedEdge = {
 	readonly createdAt: Scalars['DateTime']
 }
 
+export enum DateFormatEnum {
+	Raw = 'RAW',
+	Full = 'FULL',
+	Short = 'SHORT',
+	Relative = 'RELATIVE',
+}
+
 /** ## Interfaces */
 export type Entity = {
 	readonly id: Scalars['UuidV4']
@@ -196,6 +203,8 @@ export type Listing = Entity & {
 	readonly owner: User
 	readonly online: Scalars['Boolean']
 	readonly status: ListingStatusEnum
+	readonly createdAt: Scalars['DateTime']
+	readonly updatedAt: Scalars['DateTime']
 	/** textual content */
 	readonly title: Scalars['NonEmptyString']
 	readonly desc: Scalars['NonEmptyString']
@@ -210,6 +219,9 @@ export type Listing = Entity & {
 	readonly category: Category
 	readonly primaryImage: Maybe<Image>
 	readonly images: Maybe<ReadonlyArray<Image>>
+	/** Formattable fields (fugly! but works) */
+	readonly forDisplayPrice: Scalars['NonEmptyString']
+	readonly forDisplayCreatedAt: Scalars['NonEmptyString']
 	/** misc */
 	readonly type: ListingTypeEnum
 	/** Bizz user only */
@@ -220,6 +232,14 @@ export type Listing = Entity & {
 	readonly location: Location
 	/** Product - package, addons, publications */
 	readonly productPackage: ProductPackage
+}
+
+export type ListingForDisplayPriceArgs = {
+	format: Maybe<PriceFormatEnum>
+}
+
+export type ListingForDisplayCreatedAtArgs = {
+	format: Maybe<DateFormatEnum>
 }
 
 /** Listing connection, paginated */
@@ -362,6 +382,13 @@ export type Phone = Entity & {
 	readonly updatedAt: Scalars['DateTime']
 }
 
+export enum PriceFormatEnum {
+	Raw = 'RAW',
+	Full = 'FULL',
+	Short = 'SHORT',
+	Relative = 'RELATIVE',
+}
+
 /** Addons, for granular tweaking of the exposure rules/features. */
 export type ProductAddon = Entity & {
 	readonly id: Scalars['UuidV4']
@@ -461,12 +488,18 @@ export type User = Entity & {
 	readonly email: Maybe<Scalars['NonEmptyString']>
 	readonly userName: Maybe<Scalars['NonEmptyString']>
 	readonly createdAt: Scalars['DateTime']
+	/** Formattable fields (fugly! but works) */
+	readonly forDisplayCreatedAt: Scalars['NonEmptyString']
 	readonly listingConnection: Maybe<ListingConnection>
 	readonly favoriteListingsConnection: Maybe<FavoriteListingConnection>
 	readonly labelsConnection: Maybe<LabelsConnection>
 	readonly receiptsConnection: Maybe<ReceiptsConnection>
 	/** TODO: Needs more args to separate type of messages (own, replies from others, etc.) */
 	readonly messagesConnection: Maybe<MessagesConnection>
+}
+
+export type UserForDisplayCreatedAtArgs = {
+	format: Maybe<DateFormatEnum>
 }
 
 export type UserListingConnectionArgs = {

--- a/src/api/src/_gen/client-types.ts
+++ b/src/api/src/_gen/client-types.ts
@@ -82,6 +82,7 @@ export type DatedEdge = {
 	readonly createdAt: Scalars['DateTime']
 }
 
+/** Available date formatting */
 export enum DateFormatEnum {
 	Raw = 'RAW',
 	Full = 'FULL',
@@ -124,6 +125,7 @@ export enum FrontpageGroupTypeEnum {
 	User = 'USER',
 }
 
+/** Available sorting options */
 export enum GenericSortBy {
 	CreatedAt = 'CREATED_AT',
 	UpdatedAt = 'UPDATED_AT',
@@ -139,6 +141,7 @@ export type ImageUrlArgs = {
 	size?: Maybe<ImageSizes>
 }
 
+/** Available image sizes */
 export enum ImageSizes {
 	Thumb = 'THUMB',
 	Small = 'SMALL',
@@ -200,6 +203,7 @@ export type Listing = Entity & {
 	/** basic */
 	readonly id: Scalars['UuidV4']
 	readonly slug: Scalars['NonEmptyString']
+	/** NOTE: directives don't work when mocking is enabled */
 	readonly owner: User
 	readonly online: Scalars['Boolean']
 	readonly status: ListingStatusEnum
@@ -382,6 +386,7 @@ export type Phone = Entity & {
 	readonly updatedAt: Scalars['DateTime']
 }
 
+/** Available price formatting */
 export enum PriceFormatEnum {
 	Raw = 'RAW',
 	Full = 'FULL',
@@ -477,7 +482,8 @@ export enum ResponseCodeEnum {
 	Error = 'ERROR',
 }
 
-export enum Role {
+/** authorization */
+export enum RoleEnum {
 	Admin = 'ADMIN',
 	User = 'USER',
 }
@@ -488,8 +494,10 @@ export type User = Entity & {
 	readonly email: Maybe<Scalars['NonEmptyString']>
 	readonly userName: Maybe<Scalars['NonEmptyString']>
 	readonly createdAt: Scalars['DateTime']
+	readonly updatedAt: Scalars['DateTime']
 	/** Formattable fields (fugly! but works) */
 	readonly forDisplayCreatedAt: Scalars['NonEmptyString']
+	readonly forDisplayUpdatedAt: Scalars['NonEmptyString']
 	readonly listingConnection: Maybe<ListingConnection>
 	readonly favoriteListingsConnection: Maybe<FavoriteListingConnection>
 	readonly labelsConnection: Maybe<LabelsConnection>
@@ -499,6 +507,10 @@ export type User = Entity & {
 }
 
 export type UserForDisplayCreatedAtArgs = {
+	format: Maybe<DateFormatEnum>
+}
+
+export type UserForDisplayUpdatedAtArgs = {
 	format: Maybe<DateFormatEnum>
 }
 

--- a/src/api/src/_gen/client-types.ts
+++ b/src/api/src/_gen/client-types.ts
@@ -199,11 +199,18 @@ export type LabelsConnection = PaginatedConnection & {
 	readonly totalCount: Scalars['Int']
 }
 
+/**
+ * This text will show up
+ * as the object's description
+ */
 export type Listing = Entity & {
-	/** basic */
+	/**
+	 * If no "string literals" (quoted text) precedes the field,
+	 * this comment will act as the field's description
+	 */
 	readonly id: Scalars['UuidV4']
 	readonly slug: Scalars['NonEmptyString']
-	/** NOTE: directives don't work when mocking is enabled */
+	/** Requires authorization! */
 	readonly owner: User
 	readonly online: Scalars['Boolean']
 	readonly status: ListingStatusEnum
@@ -223,7 +230,7 @@ export type Listing = Entity & {
 	readonly category: Category
 	readonly primaryImage: Maybe<Image>
 	readonly images: Maybe<ReadonlyArray<Image>>
-	/** Formattable fields (fugly! but works) */
+	/** Computed field */
 	readonly forDisplayPrice: Scalars['NonEmptyString']
 	readonly forDisplayCreatedAt: Scalars['NonEmptyString']
 	/** misc */
@@ -238,10 +245,18 @@ export type Listing = Entity & {
 	readonly productPackage: ProductPackage
 }
 
+/**
+ * This text will show up
+ * as the object's description
+ */
 export type ListingForDisplayPriceArgs = {
 	format: Maybe<PriceFormatEnum>
 }
 
+/**
+ * This text will show up
+ * as the object's description
+ */
 export type ListingForDisplayCreatedAtArgs = {
 	format: Maybe<DateFormatEnum>
 }

--- a/src/api/src/_gen/server-types.ts
+++ b/src/api/src/_gen/server-types.ts
@@ -90,6 +90,13 @@ export type GQLDatedEdge = {
 	readonly createdAt: Scalars['DateTime']
 }
 
+export enum GQLDateFormatEnum {
+	Raw = 'RAW',
+	Full = 'FULL',
+	Short = 'SHORT',
+	Relative = 'RELATIVE',
+}
+
 /** ## Interfaces */
 export type GQLEntity = {
 	readonly id: Scalars['UuidV4']
@@ -204,6 +211,8 @@ export type GQLListing = GQLEntity & {
 	readonly owner: GQLUser
 	readonly online: Scalars['Boolean']
 	readonly status: GQLListingStatusEnum
+	readonly createdAt: Scalars['DateTime']
+	readonly updatedAt: Scalars['DateTime']
 	/** textual content */
 	readonly title: Scalars['NonEmptyString']
 	readonly desc: Scalars['NonEmptyString']
@@ -218,6 +227,9 @@ export type GQLListing = GQLEntity & {
 	readonly category: GQLCategory
 	readonly primaryImage: Maybe<GQLImage>
 	readonly images: Maybe<ReadonlyArray<GQLImage>>
+	/** Formattable fields (fugly! but works) */
+	readonly forDisplayPrice: Scalars['NonEmptyString']
+	readonly forDisplayCreatedAt: Scalars['NonEmptyString']
 	/** misc */
 	readonly type: GQLListingTypeEnum
 	/** Bizz user only */
@@ -228,6 +240,14 @@ export type GQLListing = GQLEntity & {
 	readonly location: GQLLocation
 	/** Product - package, addons, publications */
 	readonly productPackage: GQLProductPackage
+}
+
+export type GQLListingForDisplayPriceArgs = {
+	format: Maybe<GQLPriceFormatEnum>
+}
+
+export type GQLListingForDisplayCreatedAtArgs = {
+	format: Maybe<GQLDateFormatEnum>
 }
 
 /** Listing connection, paginated */
@@ -370,6 +390,13 @@ export type GQLPhone = GQLEntity & {
 	readonly updatedAt: Scalars['DateTime']
 }
 
+export enum GQLPriceFormatEnum {
+	Raw = 'RAW',
+	Full = 'FULL',
+	Short = 'SHORT',
+	Relative = 'RELATIVE',
+}
+
 /** Addons, for granular tweaking of the exposure rules/features. */
 export type GQLProductAddon = GQLEntity & {
 	readonly id: Scalars['UuidV4']
@@ -469,12 +496,18 @@ export type GQLUser = GQLEntity & {
 	readonly email: Maybe<Scalars['NonEmptyString']>
 	readonly userName: Maybe<Scalars['NonEmptyString']>
 	readonly createdAt: Scalars['DateTime']
+	/** Formattable fields (fugly! but works) */
+	readonly forDisplayCreatedAt: Scalars['NonEmptyString']
 	readonly listingConnection: Maybe<GQLListingConnection>
 	readonly favoriteListingsConnection: Maybe<GQLFavoriteListingConnection>
 	readonly labelsConnection: Maybe<GQLLabelsConnection>
 	readonly receiptsConnection: Maybe<GQLReceiptsConnection>
 	/** TODO: Needs more args to separate type of messages (own, replies from others, etc.) */
 	readonly messagesConnection: Maybe<GQLMessagesConnection>
+}
+
+export type GQLUserForDisplayCreatedAtArgs = {
+	format: Maybe<GQLDateFormatEnum>
 }
 
 export type GQLUserListingConnectionArgs = {
@@ -583,6 +616,7 @@ export type GQLResolversTypes = {
 	UuidV4: ResolverTypeWrapper<UuidV4>
 	User: ResolverTypeWrapper<any>
 	DateTime: ResolverTypeWrapper<ValidDate>
+	DateFormatEnum: ResolverTypeWrapper<any>
 	ListingConnection: ResolverTypeWrapper<any>
 	PaginatedConnection: ResolverTypeWrapper<any>
 	PageInfo: ResolverTypeWrapper<any>
@@ -613,6 +647,7 @@ export type GQLResolversTypes = {
 	Category: ResolverTypeWrapper<any>
 	Image: ResolverTypeWrapper<any>
 	ImageSizes: ResolverTypeWrapper<any>
+	PriceFormatEnum: ResolverTypeWrapper<any>
 	ListingTypeEnum: ResolverTypeWrapper<any>
 	Location: ResolverTypeWrapper<any>
 	Country: ResolverTypeWrapper<any>
@@ -643,6 +678,7 @@ export type GQLResolversParentTypes = {
 	UuidV4: UuidV4
 	User: any
 	DateTime: ValidDate
+	DateFormatEnum: any
 	ListingConnection: any
 	PaginatedConnection: any
 	PageInfo: any
@@ -671,6 +707,7 @@ export type GQLResolversParentTypes = {
 	Category: any
 	Image: any
 	ImageSizes: any
+	PriceFormatEnum: any
 	ListingTypeEnum: any
 	Location: any
 	Country: any
@@ -893,6 +930,8 @@ export type GQLListingResolvers<
 	owner: Resolver<GQLResolversTypes['User'], ParentType, ContextType>
 	online: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>
 	status: Resolver<GQLResolversTypes['ListingStatusEnum'], ParentType, ContextType>
+	createdAt: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+	updatedAt: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
 	title: Resolver<GQLResolversTypes['NonEmptyString'], ParentType, ContextType>
 	desc: Resolver<GQLResolversTypes['NonEmptyString'], ParentType, ContextType>
 	publicationTitle: Resolver<GQLResolversTypes['NonEmptyString'], ParentType, ContextType>
@@ -903,6 +942,13 @@ export type GQLListingResolvers<
 	category: Resolver<GQLResolversTypes['Category'], ParentType, ContextType>
 	primaryImage: Resolver<Maybe<GQLResolversTypes['Image']>, ParentType, ContextType>
 	images: Resolver<Maybe<ReadonlyArray<GQLResolversTypes['Image']>>, ParentType, ContextType>
+	forDisplayPrice: Resolver<GQLResolversTypes['NonEmptyString'], ParentType, ContextType, GQLListingForDisplayPriceArgs>
+	forDisplayCreatedAt: Resolver<
+		GQLResolversTypes['NonEmptyString'],
+		ParentType,
+		ContextType,
+		GQLListingForDisplayCreatedAtArgs
+	>
 	type: Resolver<GQLResolversTypes['ListingTypeEnum'], ParentType, ContextType>
 	homepage: Resolver<Maybe<GQLResolversTypes['NonEmptyString']>, ParentType, ContextType>
 	phone: Resolver<Maybe<GQLResolversTypes['NonEmptyString']>, ParentType, ContextType>
@@ -1149,6 +1195,12 @@ export type GQLUserResolvers<
 	email: Resolver<Maybe<GQLResolversTypes['NonEmptyString']>, ParentType, ContextType>
 	userName: Resolver<Maybe<GQLResolversTypes['NonEmptyString']>, ParentType, ContextType>
 	createdAt: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+	forDisplayCreatedAt: Resolver<
+		GQLResolversTypes['NonEmptyString'],
+		ParentType,
+		ContextType,
+		GQLUserForDisplayCreatedAtArgs
+	>
 	listingConnection: Resolver<
 		Maybe<GQLResolversTypes['ListingConnection']>,
 		ParentType,

--- a/src/api/src/_gen/server-types.ts
+++ b/src/api/src/_gen/server-types.ts
@@ -207,11 +207,18 @@ export type GQLLabelsConnection = GQLPaginatedConnection & {
 	readonly totalCount: Scalars['Int']
 }
 
+/**
+ * This text will show up
+ * as the object's description
+ */
 export type GQLListing = GQLEntity & {
-	/** basic */
+	/**
+	 * If no "string literals" (quoted text) precedes the field,
+	 * this comment will act as the field's description
+	 */
 	readonly id: Scalars['UuidV4']
 	readonly slug: Scalars['NonEmptyString']
-	/** NOTE: directives don't work when mocking is enabled */
+	/** Requires authorization! */
 	readonly owner: GQLUser
 	readonly online: Scalars['Boolean']
 	readonly status: GQLListingStatusEnum
@@ -231,7 +238,7 @@ export type GQLListing = GQLEntity & {
 	readonly category: GQLCategory
 	readonly primaryImage: Maybe<GQLImage>
 	readonly images: Maybe<ReadonlyArray<GQLImage>>
-	/** Formattable fields (fugly! but works) */
+	/** Computed field */
 	readonly forDisplayPrice: Scalars['NonEmptyString']
 	readonly forDisplayCreatedAt: Scalars['NonEmptyString']
 	/** misc */
@@ -246,10 +253,18 @@ export type GQLListing = GQLEntity & {
 	readonly productPackage: GQLProductPackage
 }
 
+/**
+ * This text will show up
+ * as the object's description
+ */
 export type GQLListingForDisplayPriceArgs = {
 	format: Maybe<GQLPriceFormatEnum>
 }
 
+/**
+ * This text will show up
+ * as the object's description
+ */
 export type GQLListingForDisplayCreatedAtArgs = {
 	format: Maybe<GQLDateFormatEnum>
 }

--- a/src/api/src/_gen/server-types.ts
+++ b/src/api/src/_gen/server-types.ts
@@ -90,6 +90,7 @@ export type GQLDatedEdge = {
 	readonly createdAt: Scalars['DateTime']
 }
 
+/** Available date formatting */
 export enum GQLDateFormatEnum {
 	Raw = 'RAW',
 	Full = 'FULL',
@@ -132,6 +133,7 @@ export enum GQLFrontpageGroupTypeEnum {
 	User = 'USER',
 }
 
+/** Available sorting options */
 export enum GQLGenericSortBy {
 	CreatedAt = 'CREATED_AT',
 	UpdatedAt = 'UPDATED_AT',
@@ -147,6 +149,7 @@ export type GQLImageUrlArgs = {
 	size?: Maybe<GQLImageSizes>
 }
 
+/** Available image sizes */
 export enum GQLImageSizes {
 	Thumb = 'THUMB',
 	Small = 'SMALL',
@@ -208,6 +211,7 @@ export type GQLListing = GQLEntity & {
 	/** basic */
 	readonly id: Scalars['UuidV4']
 	readonly slug: Scalars['NonEmptyString']
+	/** NOTE: directives don't work when mocking is enabled */
 	readonly owner: GQLUser
 	readonly online: Scalars['Boolean']
 	readonly status: GQLListingStatusEnum
@@ -390,6 +394,7 @@ export type GQLPhone = GQLEntity & {
 	readonly updatedAt: Scalars['DateTime']
 }
 
+/** Available price formatting */
 export enum GQLPriceFormatEnum {
 	Raw = 'RAW',
 	Full = 'FULL',
@@ -485,7 +490,8 @@ export enum GQLResponseCodeEnum {
 	Error = 'ERROR',
 }
 
-export enum GQLRole {
+/** authorization */
+export enum GQLRoleEnum {
 	Admin = 'ADMIN',
 	User = 'USER',
 }
@@ -496,8 +502,10 @@ export type GQLUser = GQLEntity & {
 	readonly email: Maybe<Scalars['NonEmptyString']>
 	readonly userName: Maybe<Scalars['NonEmptyString']>
 	readonly createdAt: Scalars['DateTime']
+	readonly updatedAt: Scalars['DateTime']
 	/** Formattable fields (fugly! but works) */
 	readonly forDisplayCreatedAt: Scalars['NonEmptyString']
+	readonly forDisplayUpdatedAt: Scalars['NonEmptyString']
 	readonly listingConnection: Maybe<GQLListingConnection>
 	readonly favoriteListingsConnection: Maybe<GQLFavoriteListingConnection>
 	readonly labelsConnection: Maybe<GQLLabelsConnection>
@@ -507,6 +515,10 @@ export type GQLUser = GQLEntity & {
 }
 
 export type GQLUserForDisplayCreatedAtArgs = {
+	format: Maybe<GQLDateFormatEnum>
+}
+
+export type GQLUserForDisplayUpdatedAtArgs = {
 	format: Maybe<GQLDateFormatEnum>
 }
 
@@ -654,11 +666,11 @@ export type GQLResolversTypes = {
 	ProductPackage: ResolverTypeWrapper<any>
 	ProductAddon: ResolverTypeWrapper<any>
 	Publication: ResolverTypeWrapper<any>
-	Role: ResolverTypeWrapper<any>
 	CategoryField: ResolverTypeWrapper<any>
 	Phone: ResolverTypeWrapper<any>
 	Email: ResolverTypeWrapper<any>
 	URL: ResolverTypeWrapper<any>
+	RoleEnum: ResolverTypeWrapper<any>
 	ResponseCodeEnum: ResolverTypeWrapper<any>
 	MutationResponse: ResolverTypeWrapper<any>
 }
@@ -714,16 +726,16 @@ export type GQLResolversParentTypes = {
 	ProductPackage: any
 	ProductAddon: any
 	Publication: any
-	Role: any
 	CategoryField: any
 	Phone: any
 	Email: any
 	URL: any
+	RoleEnum: any
 	ResponseCodeEnum: any
 	MutationResponse: any
 }
 
-export type GQLAuthDirectiveArgs = { requires?: Maybe<GQLRole> }
+export type GQLAuthDirectiveArgs = { requires?: Maybe<GQLRoleEnum> }
 
 export type GQLAuthDirectiveResolver<
 	Result,
@@ -1195,11 +1207,18 @@ export type GQLUserResolvers<
 	email: Resolver<Maybe<GQLResolversTypes['NonEmptyString']>, ParentType, ContextType>
 	userName: Resolver<Maybe<GQLResolversTypes['NonEmptyString']>, ParentType, ContextType>
 	createdAt: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
+	updatedAt: Resolver<GQLResolversTypes['DateTime'], ParentType, ContextType>
 	forDisplayCreatedAt: Resolver<
 		GQLResolversTypes['NonEmptyString'],
 		ParentType,
 		ContextType,
 		GQLUserForDisplayCreatedAtArgs
+	>
+	forDisplayUpdatedAt: Resolver<
+		GQLResolversTypes['NonEmptyString'],
+		ParentType,
+		ContextType,
+		GQLUserForDisplayUpdatedAtArgs
 	>
 	listingConnection: Resolver<
 		Maybe<GQLResolversTypes['ListingConnection']>,

--- a/src/api/src/directives/Auth.ts
+++ b/src/api/src/directives/Auth.ts
@@ -1,61 +1,58 @@
-// import { SchemaDirectiveVisitor } from "apollo-server";
-// import { GraphQLField, GraphQLObjectType, GraphQLEnumValue } from 'graphql'
-//
-// export default class AuthDirective extends SchemaDirectiveVisitor {
-//
-// 	visitObject(type:GraphQLObjectType) {
-// 		this.ensureFieldsWrapped(type);
-// 		type._requiredAuthRole = this.args.requires;
-// 	}
-// 	// // Visitor methods for nested types like fields and arguments
-// 	// // also receive a details object that provides information about
-// 	// // the parent and grandparent types.
-// 	visitFieldDefinition(field:GraphQLField<any, any>, details:) {
-// 		this.ensureFieldsWrapped(details.objectType);
-// 		field._requiredAuthRole = this.args.requires;
-// 	}
-// 	//
-// 	ensureFieldsWrapped(objectType:GraphQLObjectType) {
-// 		// Mark the GraphQLObjectType object to avoid re-wrapping:
-// 		if (objectType._authFieldsWrapped) return;
-// 		objectType._authFieldsWrapped = true;
-//
-// 		const fields = objectType.getFields();
-//
-// 		Object.keys(fields).forEach(fieldName => {
-// 			const field = fields[fieldName];
-// 			const { resolve = defaultFieldResolver } = field;
-// 			field.resolve = async function (...args) {
-// 				// Get the required Role from the field first, falling back
-// 				// to the objectType if no Role is required by the field:
-// 				const requiredRole =
-// 					field._requiredAuthRole ||
-// 					objectType._requiredAuthRole;
-//
-// 				if (! requiredRole) {
-// 					return resolve.apply(this, args);
-// 				}
-//
-// 				const context = args[2];
-// 				const user = await getUser(context.headers.authToken);
-// 				if (! user.hasRole(requiredRole)) {
-// 					throw new Error("not authorized");
-// 				}
-//
-// 				return resolve.apply(this, args);
-// 			};
-// 		});
-// 	}
-// }
-//
-// class DeprecatedDirective extends SchemaDirectiveVisitor {
-// 	public visitFieldDefinition(field: GraphQLField<any, any>) {
-// 		field.isDeprecated = true;
-// 		field.deprecationReason = this.args.reason;
-// 	}
-//
-// 	public visitEnumValue(value: GraphQLEnumValue) {
-// 		value.isDeprecated = true;
-// 		value.deprecationReason = this.args.reason;
-// 	}
-// }
+import { SchemaDirectiveVisitor } from 'apollo-server'
+import { GraphQLField, GraphQLObjectType, defaultFieldResolver } from 'graphql'
+
+// Copy pasta from the apollo-server docs, typed
+// with custom logic resolving when a
+export class AuthDirective extends SchemaDirectiveVisitor {
+	visitObject(type: GraphQLObjectType) {
+		this.ensureFieldsWrapped(type)
+		// @ts-ignore
+		type._requiredAuthRole = this.args.requires
+	}
+	// Visitor methods for nested types like fields and arguments
+	// also receive a details object that provides information about
+	// the parent and grandparent types.
+	visitFieldDefinition(field: GraphQLField<any, any>, details: any) {
+		this.ensureFieldsWrapped(details.objectType)
+		// @ts-ignore
+		field._requiredAuthRole = this.args.requires
+	}
+
+	// Wrap object and nested fields
+	ensureFieldsWrapped(objectType: GraphQLObjectType) {
+		// Mark the GraphQLObjectType object to avoid re-wrapping:
+		// @ts-ignore
+		if (objectType._authFieldsWrapped) {
+			return
+		}
+
+		// @ts-ignore
+		objectType._authFieldsWrapped = true
+
+		const fields = objectType.getFields()
+
+		Object.keys(fields).forEach(fieldName => {
+			const field = fields[fieldName]
+			const { resolve = defaultFieldResolver } = field
+			field.resolve = async function(...args) {
+				// Get the required Role from the field first, falling back
+				// to the objectType if no Role is required by the field:
+				// @ts-ignore
+				const requiredRole = field._requiredAuthRole || objectType._requiredAuthRole
+
+				// no role defined, ignore directive
+				if (!requiredRole) {
+					return resolve.apply(this, args)
+				}
+
+				// see: src/api/src/schemaV2/context.ts
+				const context = args[2]
+				if (!context.auth.authenticated) {
+					throw new Error('Not authorized')
+				}
+
+				return resolve.apply(this, args)
+			}
+		})
+	}
+}

--- a/src/api/src/directives/index.ts
+++ b/src/api/src/directives/index.ts
@@ -1,1 +1,2 @@
 export * from './Deprecated'
+export * from './Auth'

--- a/src/api/src/index.ts
+++ b/src/api/src/index.ts
@@ -4,7 +4,7 @@ import * as express from 'express'
 import { GraphQLResolveInfo } from 'graphql'
 import { applyMiddleware } from 'graphql-middleware'
 import { mocks } from './clients'
-import { DeprecatedDirective } from './directives'
+import { DeprecatedDirective, AuthDirective } from './directives'
 // import { default as resolvers } from './resolvers'
 import { default as typeDefs } from './schemaV2'
 import { Context, contextFn } from './schemaV2/context'
@@ -78,6 +78,7 @@ const server = new ApolloServer({
 	resolvers: {},
 	schemaDirectives: {
 		deprecated: DeprecatedDirective,
+		auth: AuthDirective,
 	},
 	tracing: true,
 	context: contextFn,

--- a/src/api/src/schemaV2/Auth.gql
+++ b/src/api/src/schemaV2/Auth.gql
@@ -1,8 +1,0 @@
-directive @auth(requires: Role = USER) on OBJECT | FIELD_DEFINITION
-
-enum Role {
-	ADMIN
-	USER
-}
-
-# TODO: Schema + types

--- a/src/api/src/schemaV2/Listing.gql
+++ b/src/api/src/schemaV2/Listing.gql
@@ -55,6 +55,8 @@ type Listing implements Entity {
 	owner: User!
 	online: Boolean!
 	status: ListingStatusEnum!
+	createdAt: DateTime!
+	updatedAt: DateTime!
 
 	# textual content
 	title: NonEmptyString!
@@ -72,6 +74,10 @@ type Listing implements Entity {
 	primaryImage: Image
 	images: [Image!]
 	# (categoryFields should be a connection on the Category entity)
+
+	# Formattable fields (fugly! but works)
+	forDisplayPrice(format: PriceFormatEnum): NonEmptyString!
+	forDisplayCreatedAt(format: DateFormatEnum): NonEmptyString!
 
 	# misc
 	type: ListingTypeEnum! #TODO: rename to something that makes sense (in the context of: selling, buying, trading, giving away for free)

--- a/src/api/src/schemaV2/Listing.gql
+++ b/src/api/src/schemaV2/Listing.gql
@@ -52,7 +52,8 @@ type Listing implements Entity {
 	# basic
 	id: UuidV4!
 	slug: NonEmptyString!
-	owner: User!
+	# NOTE: directives don't work when mocking is enabled
+	owner: User! @auth(requires: USER)
 	online: Boolean!
 	status: ListingStatusEnum!
 	createdAt: DateTime!

--- a/src/api/src/schemaV2/Listing.gql
+++ b/src/api/src/schemaV2/Listing.gql
@@ -48,11 +48,17 @@ type ListingEdge implements DatedEdge {
 	createdAt: DateTime!
 }
 
+# This text will act as a code comment
+"""
+This text will show up
+as the object's description
+"""
 type Listing implements Entity {
-	# basic
+	# If no "string literals" (quoted text) precedes the field,
+	# this comment will act as the field's description
 	id: UuidV4!
 	slug: NonEmptyString!
-	# NOTE: directives don't work when mocking is enabled
+	"Requires authorization!"
 	owner: User! @auth(requires: USER)
 	online: Boolean!
 	status: ListingStatusEnum!
@@ -77,6 +83,7 @@ type Listing implements Entity {
 	# (categoryFields should be a connection on the Category entity)
 
 	# Formattable fields (fugly! but works)
+	"Computed field"
 	forDisplayPrice(format: PriceFormatEnum): NonEmptyString!
 	forDisplayCreatedAt(format: DateFormatEnum): NonEmptyString!
 

--- a/src/api/src/schemaV2/User.gql
+++ b/src/api/src/schemaV2/User.gql
@@ -5,6 +5,9 @@ type User implements Entity {
 	userName: NonEmptyString
 	createdAt: DateTime!
 
+	# Formattable fields (fugly! but works)
+	forDisplayCreatedAt(format: DateFormatEnum): NonEmptyString!
+
 	listingConnection(
 		cursor: CursorPaginationParams
 		sortBy: ListingOrderEnum = CREATED_AT

--- a/src/api/src/schemaV2/User.gql
+++ b/src/api/src/schemaV2/User.gql
@@ -4,9 +4,11 @@ type User implements Entity {
 	email: NonEmptyString # TODO: Implement a custom "Email" Scalar?
 	userName: NonEmptyString
 	createdAt: DateTime!
+	updatedAt: DateTime!
 
 	# Formattable fields (fugly! but works)
 	forDisplayCreatedAt(format: DateFormatEnum): NonEmptyString!
+	forDisplayUpdatedAt(format: DateFormatEnum): NonEmptyString!
 
 	listingConnection(
 		cursor: CursorPaginationParams

--- a/src/api/src/schemaV2/_Shared.gql
+++ b/src/api/src/schemaV2/_Shared.gql
@@ -1,14 +1,17 @@
-### All things that are shareable (without ownership)
+### All things that are shareable (without obvious ownership)
 
 ### Annotations / Directives
+# deprecated stuff
 directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
 
-#enum RoleEnum {
-#	ADMIN
-#	USER
-#}
-#directive @auth(requires: RoleEnum = USER) on OBJECT | FIELD_DEFINITION
+# authorization
+enum RoleEnum {
+	ADMIN
+	USER
+}
+directive @auth(requires: RoleEnum = USER) on OBJECT | FIELD_DEFINITION
 
+# Available date formatting
 enum DateFormatEnum {
 	RAW
 	FULL
@@ -16,6 +19,7 @@ enum DateFormatEnum {
 	RELATIVE
 }
 
+# Available price formatting
 enum PriceFormatEnum {
 	RAW
 	FULL
@@ -36,6 +40,7 @@ interface DatedEdge {
 	# updatedAt: DateTime!
 }
 
+# Available sorting options
 enum GenericSortBy {
 	CREATED_AT
 	UPDATED_AT
@@ -64,6 +69,7 @@ type Location {
 	long: NonEmptyString
 }
 
+# Available image sizes
 enum ImageSizes {
 	THUMB
 	SMALL

--- a/src/api/src/schemaV2/_Shared.gql
+++ b/src/api/src/schemaV2/_Shared.gql
@@ -3,6 +3,26 @@
 ### Annotations / Directives
 directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
 
+#enum RoleEnum {
+#	ADMIN
+#	USER
+#}
+#directive @auth(requires: RoleEnum = USER) on OBJECT | FIELD_DEFINITION
+
+enum DateFormatEnum {
+	RAW
+	FULL
+	SHORT
+	RELATIVE
+}
+
+enum PriceFormatEnum {
+	RAW
+	FULL
+	SHORT
+	RELATIVE
+}
+
 ### Interfaces
 interface Entity {
 	id: UuidV4!

--- a/src/api/src/schemaV2/context.ts
+++ b/src/api/src/schemaV2/context.ts
@@ -19,9 +19,9 @@ interface ExpressContext {
 	res: express.Response
 }
 
-export let contextFn = async ({ req, res }: ExpressContext): Promise<Context> => {
-	let requestId = req.header('x-request-id') ? req.header('x-request-id')! : 'UNTRACEABLE'
-	let context = {
+export const contextFn = async ({ req, res }: ExpressContext): Promise<Context> => {
+	const requestId = req.header('x-request-id') ? req.header('x-request-id')! : 'UNTRACEABLE'
+	const context = {
 		danger: {
 			'gg-user-segment': req.header('gg-user-segment'),
 			'gg-user-type': req.header('gg-user-type'),
@@ -33,7 +33,8 @@ export let contextFn = async ({ req, res }: ExpressContext): Promise<Context> =>
 	}
 	return {
 		auth: {
-			authenticated: false,
+			// TODO: validate token from `req.headers.authorization`
+			authenticated: !!req.header('gg-user-type') && req.header('gg-user-type') !== 'anon',
 			roles: [],
 		},
 		trace: { requestId, path: [] },

--- a/src/api/src/schemaV2/context.ts
+++ b/src/api/src/schemaV2/context.ts
@@ -35,6 +35,7 @@ export const contextFn = async ({ req, res }: ExpressContext): Promise<Context> 
 		auth: {
 			// TODO: validate token from `req.headers.authorization`
 			authenticated: !!req.header('gg-user-type') && req.header('gg-user-type') !== 'anon',
+			// TODO: extract the roles from headers
 			roles: [],
 		},
 		trace: { requestId, path: [] },


### PR DESCRIPTION
- changed how schema directives are registered
- auth directive for resolving authenticated users (resolving roles is still a todo)
- deprecated directive for marking fields as deprecated with a short description
- using string literals inside the schema, to add object/field descriptions in code + api
  - might be useful to mark fields as computed?